### PR TITLE
Remove obsolete CXX_STD = CXX11 to allow Armadillo 15.0.x migration

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,15 +1,3 @@
-
-## With R 3.1.0 or later, you can uncomment the following line to tell R to 
-## enable compilation with C++11 (where available)
-##
-## Also, OpenMP support in Armadillo prefers C++11 support. However, for wider
-## availability of the package we do not yet enforce this here.  It is however
-## recommended for client packages to set it.
-##
-## And with R 3.4.0, and RcppArmadillo 0.7.960.*, we turn C++11 on as OpenMP
-## support within Armadillo prefers / requires it
-CXX_STD = CXX11
-
 PKG_CPPFLAGS = -I. -I../inst/include
 PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS) 
 PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,15 +1,3 @@
-
-## With R 3.1.0 or later, you can uncomment the following line to tell R to 
-## enable compilation with C++11 (where available)
-##
-## Also, OpenMP support in Armadillo prefers C++11 support. However, for wider
-## availability of the package we do not yet enforce this here.  It is however
-## recommended for client packages to set it.
-##
-## And with R 3.4.0, and RcppArmadillo 0.7.960.*, we turn C++11 on as OpenMP
-## support within Armadillo prefers / requires it
-CXX_STD = CXX11
-
 PKG_CPPFLAGS = -I. -I../inst/include
 PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS) 
 PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)


### PR DESCRIPTION
Armadillo 15.0.* now makes C++14 the minimum compilation standard. For most packages, adapting to it can be very simple, and yours is one of them. In this PR we simply remove the declaration from Makevars and Makevars.win -- and no other changes are needed.

Please see issues [#475](https://github.com/RcppCore/RcppArmadillo/issues/475) and below for context, and notably [#489](https://github.com/RcppCore/RcppArmadillo/issues/489) for this first wave of PRs. It would be terrific if you could make an upload to CRAN 'soon' to remove the reliance on C++11 which we needed in the past, but which is by now a hindrance.  Of course, CRAN also now wants you to remove C++11 use and imposed a deadline on your package.  Using the PR and re-uploading will help you meet this.

Please do not hesitate to reach out if I can assist in any way or clarify matters.